### PR TITLE
feat: Implement stage-specific sky color system

### DIFF
--- a/public/data/stages.json
+++ b/public/data/stages.json
@@ -29,6 +29,11 @@
         }
       ],
       "world": {
+        "sky": {
+          "type": "gradient",
+          "gradientTop": "#87CEEB",
+          "gradientBottom": "#E0F6FF"
+        },
         "lights": [
           {
             "type": "ambient",

--- a/public/src/core/scene-manager.js
+++ b/public/src/core/scene-manager.js
@@ -107,6 +107,14 @@ export class SceneManager {
    * Set the default sky color
    */
   setDefaultSkyColor() {
+    // Dispose any existing background texture to avoid leaks
+    if (
+      this.scene.background &&
+      this.scene.background.isTexture &&
+      typeof this.scene.background.dispose === 'function'
+    ) {
+      this.scene.background.dispose();
+    }
     this.scene.background = new THREE.Color(DefaultSkyColors.DEFAULT);
   }
 
@@ -115,6 +123,14 @@ export class SceneManager {
    * @param {string|number} color - Color in hex format (e.g., "#87CEEB" or 0x87ceeb)
    */
   setSkyColor(color) {
+    // Dispose any existing background texture to avoid leaks
+    if (
+      this.scene.background &&
+      this.scene.background.isTexture &&
+      typeof this.scene.background.dispose === 'function'
+    ) {
+      this.scene.background.dispose();
+    }
     this.scene.background = new THREE.Color(color);
   }
 
@@ -148,6 +164,15 @@ export class SceneManager {
     // Fill canvas with gradient
     context.fillStyle = gradient;
     context.fillRect(0, 0, canvas.width, canvas.height);
+
+    // Dispose any existing background texture to avoid leaks
+    if (
+      this.scene.background &&
+      this.scene.background.isTexture &&
+      typeof this.scene.background.dispose === 'function'
+    ) {
+      this.scene.background.dispose();
+    }
 
     // Create texture and set as background
     const texture = new THREE.CanvasTexture(canvas);

--- a/public/src/core/scene-manager.js
+++ b/public/src/core/scene-manager.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { Light } from '../world/light.js';
+import { SkyTypes, DefaultSkyColors } from '../utils/constants.js';
 
 export class SceneManager {
   constructor() {
@@ -29,7 +30,8 @@ export class SceneManager {
     this.renderer.domElement.classList.add('hidden');
     document.body.appendChild(this.renderer.domElement);
 
-    this.scene.background = new THREE.Color(0x87ceeb);
+    // Set default sky color
+    this.setDefaultSkyColor();
 
     window.addEventListener('resize', this._onResize, false);
   }
@@ -99,5 +101,87 @@ export class SceneManager {
     this._gameElements.forEach((element) => {
       element.visible = true;
     });
+  }
+
+  /**
+   * Set the default sky color
+   */
+  setDefaultSkyColor() {
+    this.scene.background = new THREE.Color(DefaultSkyColors.DEFAULT);
+  }
+
+  /**
+   * Set sky color from hex string or number
+   * @param {string|number} color - Color in hex format (e.g., "#87CEEB" or 0x87ceeb)
+   */
+  setSkyColor(color) {
+    this.scene.background = new THREE.Color(color);
+  }
+
+  /**
+   * Set sky gradient (creates a gradient background)
+   * @param {string|number} topColor - Top color of gradient
+   * @param {string|number} bottomColor - Bottom color of gradient
+   */
+  setSkyGradient(topColor, bottomColor) {
+    // Create a gradient texture
+    const canvas = document.createElement('canvas');
+    canvas.width = 256;
+    canvas.height = 256;
+    const context = canvas.getContext('2d');
+
+    // Create gradient
+    const gradient = context.createLinearGradient(0, 0, 0, canvas.height);
+    gradient.addColorStop(
+      0,
+      typeof topColor === 'string'
+        ? topColor
+        : `#${topColor.toString(16).padStart(6, '0')}`
+    );
+    gradient.addColorStop(
+      1,
+      typeof bottomColor === 'string'
+        ? bottomColor
+        : `#${bottomColor.toString(16).padStart(6, '0')}`
+    );
+
+    // Fill canvas with gradient
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    // Create texture and set as background
+    const texture = new THREE.CanvasTexture(canvas);
+    this.scene.background = texture;
+  }
+
+  /**
+   * Set sky configuration from stage data
+   * @param {Object} skyConfig - Sky configuration object
+   */
+  setSkyFromConfig(skyConfig) {
+    if (!skyConfig) {
+      this.setDefaultSkyColor();
+      return;
+    }
+
+    switch (skyConfig.type) {
+      case SkyTypes.COLOR:
+        this.setSkyColor(skyConfig.color || DefaultSkyColors.DEFAULT);
+        break;
+      case SkyTypes.GRADIENT:
+        this.setSkyGradient(
+          skyConfig.gradientTop ||
+            skyConfig.color ||
+            DefaultSkyColors.GRADIENT_TOP,
+          skyConfig.gradientBottom ||
+            skyConfig.color ||
+            DefaultSkyColors.GRADIENT_BOTTOM
+        );
+        break;
+      default:
+        // Default to color if type is not specified
+        this.setSkyColor(skyConfig.color || DefaultSkyColors.DEFAULT);
+        break;
+    }
   }
 }

--- a/public/src/core/stage-manager.js
+++ b/public/src/core/stage-manager.js
@@ -218,6 +218,16 @@ export class StageManager {
       );
     }
 
+    // Set up sky first (background should be set before lights)
+    if (stageData.world.sky) {
+      this.setupSky(stageData.world.sky);
+    } else {
+      // Use default sky if no configuration
+      if (this.game.sceneManager) {
+        this.game.sceneManager.setDefaultSkyColor();
+      }
+    }
+
     // Set up lights
     if (stageData.world.lights) {
       this.setupLights(stageData.world.lights);
@@ -324,8 +334,15 @@ export class StageManager {
 
   setupLights(lights) {
     // Use the Light class for consistent lighting management
-    if (this.game.sceneManager.light) {
+    if (this.game.sceneManager?.light) {
       this.game.sceneManager.light.setupLightsFromConfig(lights);
+    }
+  }
+
+  setupSky(skyConfig) {
+    // Set sky configuration from stage data
+    if (this.game.sceneManager) {
+      this.game.sceneManager.setSkyFromConfig(skyConfig);
     }
   }
 
@@ -506,6 +523,11 @@ export class StageManager {
 
     // Clean up stage lights (lights are managed by SceneManager.light)
     // No specific cleanup needed as lights are reset when new stage loads
+
+    // Reset sky to default
+    if (this.game.sceneManager) {
+      this.game.sceneManager.setDefaultSkyColor();
+    }
 
     // Clean up terrains
     if (this.game.entities.world.terrains) {

--- a/public/src/core/stage-manager.js
+++ b/public/src/core/stage-manager.js
@@ -205,6 +205,16 @@ export class StageManager {
   async loadStageWorld(stageData) {
     if (!stageData.world) return;
 
+    // Set up sky first (background should be set before world objects to reduce flicker)
+    if (stageData.world.sky) {
+      this.setupSky(stageData.world.sky);
+    } else {
+      // Use default sky if no configuration
+      if (this.game.sceneManager) {
+        this.game.sceneManager.setDefaultSkyColor();
+      }
+    }
+
     // Load terrains
     if (stageData.world.terrains) {
       await this.loadTerrains(stageData.world.terrains, stageData.areas);
@@ -216,16 +226,6 @@ export class StageManager {
         stageData.world.environments,
         stageData.areas
       );
-    }
-
-    // Set up sky first (background should be set before lights)
-    if (stageData.world.sky) {
-      this.setupSky(stageData.world.sky);
-    } else {
-      // Use default sky if no configuration
-      if (this.game.sceneManager) {
-        this.game.sceneManager.setDefaultSkyColor();
-      }
     }
 
     // Set up lights

--- a/public/src/core/stage-manager.js
+++ b/public/src/core/stage-manager.js
@@ -206,14 +206,7 @@ export class StageManager {
     if (!stageData.world) return;
 
     // Set up sky first (background should be set before world objects to reduce flicker)
-    if (stageData.world.sky) {
-      this.setupSky(stageData.world.sky);
-    } else {
-      // Use default sky if no configuration
-      if (this.game.sceneManager) {
-        this.game.sceneManager.setDefaultSkyColor();
-      }
-    }
+    this.setupSky(stageData.world.sky);
 
     // Load terrains
     if (stageData.world.terrains) {
@@ -229,9 +222,7 @@ export class StageManager {
     }
 
     // Set up lights
-    if (stageData.world.lights) {
-      this.setupLights(stageData.world.lights);
-    }
+    this.setupLights(stageData.world.lights);
   }
 
   async loadTerrains(terrains, areas) {
@@ -332,17 +323,42 @@ export class StageManager {
     }
   }
 
-  setupLights(lights) {
-    // Use the Light class for consistent lighting management
-    if (this.game.sceneManager?.light) {
-      this.game.sceneManager.light.setupLightsFromConfig(lights);
+  setupSky(skyConfig) {
+    // Centralize sky application, including fallback and error guard
+    if (!this.game.sceneManager) return;
+
+    try {
+      if (skyConfig) {
+        this.game.sceneManager.setSkyFromConfig(skyConfig);
+      } else {
+        this.game.sceneManager.setDefaultSkyColor();
+      }
+    } catch (err) {
+      console.warn(
+        'Invalid sky configuration; falling back to default sky.',
+        err
+      );
+      this.game.sceneManager.setDefaultSkyColor();
     }
   }
 
-  setupSky(skyConfig) {
-    // Set sky configuration from stage data
-    if (this.game.sceneManager) {
-      this.game.sceneManager.setSkyFromConfig(skyConfig);
+  setupLights(lights) {
+    // Use the Light class for consistent lighting management
+    if (!this.game.sceneManager?.light) return;
+
+    try {
+      if (lights && lights.length > 0) {
+        this.game.sceneManager.light.setupLightsFromConfig(lights);
+      } else {
+        // Use default lights if no configuration
+        this.game.sceneManager.light.setupDefaultLights();
+      }
+    } catch (err) {
+      console.warn(
+        'Invalid light configuration; falling back to default lights.',
+        err
+      );
+      this.game.sceneManager.light.setupDefaultLights();
     }
   }
 

--- a/public/src/utils/constants.js
+++ b/public/src/utils/constants.js
@@ -65,6 +65,18 @@ export const StageBGMConditions = {
   DANGER: 'danger',
 };
 
+export const SkyTypes = {
+  COLOR: 'color',
+  GRADIENT: 'gradient',
+  SKYBOX: 'skybox',
+};
+
+export const DefaultSkyColors = {
+  DEFAULT: 0x87ceeb, // Default sky blue
+  GRADIENT_TOP: 0x87ceeb, // Sky blue for gradient top
+  GRADIENT_BOTTOM: 0xe0f6ff, // Light blue for gradient bottom
+};
+
 export const LightTypes = {
   AMBIENT: 'ambient',
   DIRECTIONAL: 'directional',


### PR DESCRIPTION
## Summary
- Implement stage-specific sky color configuration system
- Add support for solid colors and gradients
- Integrate sky setup in stage loading process

## Technical Changes
### Constants (`constants.js`)
- Add `SkyTypes` enum (COLOR, GRADIENT, SKYBOX)
- Add `DefaultSkyColors` constants

### SceneManager (`scene-manager.js`)
- `setDefaultSkyColor()` - Set default sky blue
- `setSkyColor(color)` - Set solid sky color
- `setSkyGradient(topColor, bottomColor)` - Create gradient sky
- `setSkyFromConfig(skyConfig)` - Configure from stage data

### StageManager (`stage-manager.js`)
- Add `setupSky(skyConfig)` method
- Integrate sky setup in stage loading (sky → lights order)
- Reset to default sky on stage unload
- Consistent caller-side validation pattern

### Stage Configuration (`stages.json`)
- Add sample sky gradient configuration:
```json
"sky": {
  "type": "gradient",
  "gradientTop": "#87CEEB",
  "gradientBottom": "#E0F6FF"
}
```

## Test plan
- [x] Code passes lint and format checks
- [ ] Stage loads with correct sky configuration
- [ ] Default sky used when no configuration provided
- [ ] Sky resets to default on stage unload
- [ ] Gradient sky renders correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-stage configurable sky (solid color, gradient or skybox); startingPlains uses a blue gradient.
  * Sky is applied early during stage load so backgrounds appear before world objects and lighting.

* **Bug Fixes**
  * Sky resets to default on stage unload to avoid visual leftovers.
  * Lighting setup is more robust and guarded to prevent errors when components are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->