### PR TITLE
feat: Implement key item removal on stage clear

### DIFF
--- a/public/data/items.json
+++ b/public/data/items.json
@@ -1,6 +1,7 @@
 {
   "potion": {
     "name": "ポーション",
+    "type": "consumable",
     "model": "items/potion.glb",
     "texture": "items/potion.png",
     "image": "items/potion.png",
@@ -9,6 +10,7 @@
   },
   "fpPotion": {
     "name": "FPポーション",
+    "type": "consumable",
     "model": "items/fp-potion.glb",
     "texture": "items/fp-potion.png",
     "image": "items/fp-potion.png",
@@ -17,14 +19,15 @@
   },
   "ancientKey": {
     "name": "古代の鍵",
+    "type": "key",
     "model": "items/ancient-key.glb",
     "texture": "items/ancient-key.png",
     "image": "items/ancient-key.png",
-    "description": "古城の最深部への扉を開く神秘の鍵",
-    "type": "key"
+    "description": "古城の最深部への扉を開く神秘の鍵"
   },
   "icePotion": {
     "name": "氷結ポーション",
+    "type": "consumable",
     "model": "items/ice-potion.glb",
     "texture": "items/ice-potion.png",
     "image": "items/ice-potion.png",
@@ -45,14 +48,15 @@
   },
   "frostCrystal": {
     "name": "霜の結晶",
+    "type": "key",
     "model": "items/frost-crystal.glb",
     "texture": "items/frost-crystal.png",
     "image": "items/frost-crystal.png",
-    "description": "雪山の最深部で凍りついた神秘の結晶。ステージクリアの証",
-    "type": "key"
+    "description": "雪山の最深部で凍りついた神秘の結晶。ステージクリアの証"
   },
   "lavaResistPotion": {
     "name": "耐熱ポーション",
+    "type": "consumable",
     "model": "items/lava-resist-potion.glb",
     "texture": "items/lava-resist-potion.png",
     "image": "items/lava-resist-potion.png",
@@ -68,18 +72,18 @@
   },
   "abyssCrystal": {
     "name": "深淵の水晶",
+    "type": "key",
     "model": "items/abyss-crystal.glb",
     "texture": "items/abyss-crystal.png",
     "image": "items/abyss-crystal.png",
-    "description": "地底洞窟の奥深くに眠る漆黒の水晶。ステージクリアの証",
-    "type": "key"
+    "description": "地底洞窟の奥深くに眠る漆黒の水晶。ステージクリアの証"
   },
   "dragonScale": {
     "name": "竜の鱗",
+    "type": "key",
     "model": "items/dragon-scale.glb",
     "texture": "items/dragon-scale.png",
     "image": "items/dragon-scale.png",
-    "description": "深淵ドラゴンから剥がれ落ちた貴重な鱗。最終決戦への道しるべ",
-    "type": "key"
+    "description": "深淵ドラゴンから剥がれ落ちた貴重な鱗。最終決戦への道しるべ"
   }
 }

--- a/public/src/core/stage-manager.js
+++ b/public/src/core/stage-manager.js
@@ -1127,6 +1127,18 @@ export class StageManager {
       // Could show a stage clear dialog here
     }
 
+    // Remove key items from player inventory when stage is cleared
+    if (
+      this.game.player &&
+      typeof this.game.player.removeKeyItems === 'function'
+    ) {
+      const removedItems = this.game.player.removeKeyItems();
+      if (removedItems.length > 0) {
+        // Could show notification about removed items here
+        // Key items removed from inventory on stage clear
+      }
+    }
+
     // Auto-transition to next stage after delay, but wait for level up processing
     if (this.hasNextStage()) {
       this.startStageTransitionTimer();

--- a/public/src/entities/characters/player.js
+++ b/public/src/entities/characters/player.js
@@ -431,7 +431,7 @@ export class Player extends Character {
       const itemData = this.game.data.items[itemId];
 
       if (itemData && itemData.type === ItemTypes.KEY) {
-        removedItems.push(itemData.name);
+        removedItems.push(itemId);
         this.inventory.splice(i, 1);
       }
     }

--- a/public/src/entities/characters/player.js
+++ b/public/src/entities/characters/player.js
@@ -421,19 +421,20 @@ export class Player extends Character {
   }
 
   removeKeyItems() {
-    if (!this.game.data.items) return;
+    if (!this.game.data.items) return [];
 
     let removedItems = [];
 
-    // Find and remove all key items
-    this.inventory = this.inventory.filter((itemId) => {
+    // Remove key items from inventory in reverse order to avoid index issues
+    for (let i = this.inventory.length - 1; i >= 0; i--) {
+      const itemId = this.inventory[i];
       const itemData = this.game.data.items[itemId];
+
       if (itemData && itemData.type === ItemTypes.KEY) {
         removedItems.push(itemData.name);
-        return false; // Remove this item
+        this.inventory.splice(i, 1);
       }
-      return true; // Keep this item
-    });
+    }
 
     // Adjust current item index if necessary
     if (
@@ -444,8 +445,6 @@ export class Player extends Character {
     } else if (this.inventory.length === 0) {
       this.currentItemIndex = 0;
     }
-
-    // Items successfully removed from inventory
 
     return removedItems;
   }

--- a/public/src/entities/characters/player.js
+++ b/public/src/entities/characters/player.js
@@ -7,6 +7,7 @@ import {
   AssetPaths,
   BuffTypes,
   DamageTypes,
+  ItemTypes,
   MovementState,
   SkillTypes,
 } from '../../utils/constants.js';
@@ -417,6 +418,36 @@ export class Player extends Character {
    */
   getItemCount(itemId) {
     return this.inventory.filter((item) => item === itemId).length;
+  }
+
+  removeKeyItems() {
+    if (!this.game.data.items) return;
+
+    let removedItems = [];
+
+    // Find and remove all key items
+    this.inventory = this.inventory.filter((itemId) => {
+      const itemData = this.game.data.items[itemId];
+      if (itemData && itemData.type === ItemTypes.KEY) {
+        removedItems.push(itemData.name);
+        return false; // Remove this item
+      }
+      return true; // Keep this item
+    });
+
+    // Adjust current item index if necessary
+    if (
+      this.currentItemIndex >= this.inventory.length &&
+      this.inventory.length > 0
+    ) {
+      this.currentItemIndex = this.inventory.length - 1;
+    } else if (this.inventory.length === 0) {
+      this.currentItemIndex = 0;
+    }
+
+    // Items successfully removed from inventory
+
+    return removedItems;
   }
 
   useCurrentSkill() {

--- a/public/src/utils/constants.js
+++ b/public/src/utils/constants.js
@@ -103,6 +103,11 @@ export const EnemyTypes = {
   BOSS: 'boss',
 };
 
+export const ItemTypes = {
+  CONSUMABLE: 'consumable',
+  KEY: 'key',
+};
+
 export const EnvironmentTypes = {
   CLOUD: 'cloud',
   GROUND: 'ground',


### PR DESCRIPTION
## Summary
- Implement automatic key item removal functionality when stage is cleared
- Remove only key-type items from player inventory upon stage completion
- Add ItemTypes constants to improve code maintainability
- Add consistent type property to all items in items.json

## Changes Made
- Add `Player.removeKeyItems()` method to remove key items from inventory
- Integrate key item removal in `StageManager.onStageClear()` method
- Add `ItemTypes` constants in `constants.js` with proper positioning
- Update `items.json` to include `type` property for all items
- Fix line endings to LF format and resolve ESLint warnings

## Test Plan
- [ ] Verify key items are removed after stage clear
- [ ] Verify other items (consumable) are not removed
- [ ] Verify inventory index is properly adjusted

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Key items are automatically removed from inventories when a stage is cleared to reduce clutter.

- Improvements
  - Items are classified as consumable or key for clearer inventory distinctions and UI consistency.

- Chores
  - Item data updated to include type classifications across relevant items; supporting constants added to standardize types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->